### PR TITLE
V2 refactor serve compress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
 module github.com/colinwilliams91/go-static-serve
 
 go 1.23.0
-
-require github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f
-
-require github.com/gorilla/mux v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f h1:gOO/tNZMjjvTKZWpY7YnXC72ULNLErRtp94LountVE8=
-github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -6,6 +6,7 @@ import "net/http"
 func CacheControlMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// *** DISABLE CACHING *** FOR DEVELOPMENT ONLY? ***
+		// TODO: revisit rm for PROD
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 		w.Header().Set("Pragma", "no-cache")
 		w.Header().Set("Expires", "0")

--- a/main.go
+++ b/main.go
@@ -4,129 +4,28 @@ import (
 	"log"
 	"mime"
 	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
+
+	"github.com/colinwilliams91/go-static-serve/internal/handlers"
+	"github.com/colinwilliams91/go-static-serve/internal/middleware"
 )
 
-// import (
-// 	"log"
-// 	"mime"
-// 	"net/http"
-
-// 	"github.com/colinwilliams91/go-static-serve/internal/handlers"
-// 	"github.com/colinwilliams91/go-static-serve/internal/middleware"
-// 	"github.com/gorilla/mux"
-// )
-
-var compressionExtensions = map[string]string{
-    ".gz":  "gzip",
-    ".br":  "br",
-}
-
+const protocol = "http"
 const host = "localhost"
 const port = ":8080"
 
-// func main() {
-//     router := mux.NewRouter()
-
-//     mime.AddExtensionType(".data", "application/octet-stream")
-
-//     router.HandleFunc("/", handlers.ServeCompressedFiles).Methods("GET")
-
-//     handler := middleware.CacheControlMiddleware(router)
-
-//     log.Printf("Serving files on http://%s%s", host, port)
-
-//     err := http.ListenAndServe(port, handler)
-
-//     if err != nil {
-//         log.Fatal(err)
-//     }
-// }
-
 func main() {
-	// Add custom MIME type mapping for .data files (e.g., Unity WebGL data files)
     mime.AddExtensionType(".data", "application/octet-stream")
 
-    // Serve static files
-    http.HandleFunc("/", serveCompressedFiles)
+    http.HandleFunc("/", handlers.ServeCompressedFiles)
 
-    // Start the server
-    log.Println("Serving files on http://localhost:8080")
-    err := http.ListenAndServe(port, nil)
+    // TODO: RM in PROD...
+    handler := middleware.CacheControlMiddleware(http.DefaultServeMux)
+
+    log.Printf("Serving files on %s://%s%s", protocol, host, port)
+
+    err := http.ListenAndServe(port, handler)
+
     if err != nil {
         log.Fatal(err)
     }
-}
-
-// serveCompressedFiles checks if the file has a compressed version (.gz or .br) and serves it with correct headers.
-func serveCompressedFiles(w http.ResponseWriter, r *http.Request) {
-    requestedPath := r.URL.Path
-	log.Printf("Requested Path from URL %s", requestedPath)
-
-    if requestedPath == "/" {
-        requestedPath = "/index.html"
-    }
-
-    // Try to serve Brotli or Gzip version if available
-    for ext, encoding := range compressionExtensions {
-		log.Printf("--iterate-- %s -- %s", ext, encoding)
-
-        compressedFilePath := filepath.Join(".", "static", requestedPath+ext)
-		log.Printf("COMPRESSED FILE PATH: %s", compressedFilePath)
-
-		if _, err := os.Stat(compressedFilePath); err == nil {
-			log.Printf("Request for %s, serving compressed file %s with encoding %s\n", requestedPath, compressedFilePath, encoding)
-
-            w.Header().Set("Content-Encoding", encoding)
-
-			serveFile(w, r, compressedFilePath)
-
-			return
-        }
-    }
-
-    // Otherwise, serve the file without compression
-    toServe := filepath.Join(".", "static", requestedPath)
-    log.Printf("~~ serving uncompressed file ~~ %s", toServe)
-    serveFile(w, r, toServe)
-}
-
-// serveFile serves the requested file and sets the correct Content-Type header.
-func serveFile(w http.ResponseWriter, r *http.Request, filePath string) {
-    ext := filepath.Ext(filePath)
-
-    // If it's a compressed file, strip the compression extension to get the base MIME type
-    if encoding, exists := compressionExtensions[ext]; exists {
-
-        baseFile := strings.TrimSuffix(filePath, ext)
-
-		ext = filepath.Ext(baseFile)
-
-		w.Header().Set("Content-Encoding", encoding)
-    }
-
-    // Detect the MIME type based on the file extension
-    mimeType := mime.TypeByExtension(ext)
-
-	// if ext == ".html" {
-	// 	mimeType = "text/html"
-	// }
-
-    if mimeType == "" {
-        mimeType = "application/octet-stream"
-    }
-
-    w.Header().Set("Content-Type", mimeType)
-
-    // *** DISABLE CACHING *** FOR DEVELOPMENT ONLY? ***
-    w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-    w.Header().Set("Pragma", "no-cache")
-    w.Header().Set("Expires", "0")
-
-    // Serve the file
-	log.Printf("Serving file: %s with MIME type: %s\n", filePath, mimeType)
-    // err := http.ServeFile(w, r, filePath)
-    http.ServeFile(w, r, filePath)
 }


### PR DESCRIPTION
_see commits_

- clean out main
- replace gorilla/mux and pat with go native `http` module
- rm manual encoding type parsing for compression `br` and `gz` (Go http handling correctly and fast!)
- rm all 3rd party libs (pat and gorilla/mux)
- psuedo code a few TODOs for prod (tech debt?)
  - revisit compressed file serves once assets get big
  - AS LONG AS encoding type is `br` or `gz` in Browser Dev Tools Network tab then Go seems to be handling natively (it is) so the extra for loop over the static assets is less performant than native
  - REMOVE CACHING headers manipulation middleware (as browser aggressive caching can't be prevented)